### PR TITLE
A first pass at better snowpack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,19 @@
 This is a not-totally-functional experiment to see what it would take to use [Snowpack](https://www.snowpack.dev/) as a base for [Sapper](https://sapper.svelte.dev).
 
 ```bash
+# 1. Check out a local dev branch of the Snowpack repo
+git clone git@github.com:pikapkg/snowpack
+cd snowpack
+git checkout wip-ssr
+yarn install && yarn build && yarn install --force
+cd ../
+
+# 2. Check out this repo (note: must be a sibling directory to "snowpack")
 git clone git@github.com:Rich-Harris/snowpack-svelte
 cd snowpack-svelte
 npm install
 
+# 3. Start the server
 npm start
 ```
 
@@ -25,10 +34,11 @@ As you navigate around, you'll likely see that the browser refreshes the page co
 
 There are various things not working:
 
-* The aforementioned problem with SSR modules being served to the client
-* The `dev` task runs two Snowpack instances in the background, but all their logging gets squelched. Perhaps there's a JavaScript API we could use instead of shelling out to `snowpack`?
+* ~~The aforementioned problem with SSR modules being served to the client~~
+* ~~HMR doesn't seem to work. Haven't investigated why~~
+* Can this dev server proxy the HMR WebSocket connection to the Snowpack dev server? If so, we can remove the hardcoded `window.HMR_WEBSOCKET_URL =` line.
+* The `dev` task runs a Snowpack instance in the background, but all logging gets squelched. Perhaps there's a JavaScript API we could use instead of shelling out to `snowpack`?
 * It would be particularly nice if there were a way to load modules from Snowpack that didn't involve fetching them over HTTP and transforming them
-* HMR doesn't seem to work. Haven't investigated why
 * For now there's only a `dev` task. I haven't yet investigated what the `build` task would look like, though I believe the output of `snowpack build` already makes a very useful input to a set of opinionated 'builders' that would take your Sapper app and turn it into packaged assets + cloud functions for places like Vercel, Netlify and so on.
 * In Sapper, CSS is injected into the SSR'd page as `<link>` elements that reflect what's depended on by the current page. Subsequently dynamically imported chunks pull in additional `.css` files as needed. This demo is using a slightly cruder mechanism — I haven't yet explored what it would take to get Sapper's behaviour here.
 * I'd like to flesh this demo out a bit more so that it resembles a more fully-fledged Sapper app (with `preload`, layouts, error pages and so on)

--- a/sapper/runtime.js
+++ b/sapper/runtime.js
@@ -24,8 +24,6 @@ async function start() {
 
 		// TODO handle preload
 
-		// This often doesn't work, because Snowpack's caching mechanism
-		// gets the SSR and DOM modules mixed up
 		component = new page.default({
 			target: document.body,
 			hydrate: true,

--- a/snowpack/client.config.json
+++ b/snowpack/client.config.json
@@ -3,10 +3,7 @@
     "svelte"
   ],
   "plugins": [
-    ["@snowpack/plugin-svelte", {
-      "generate": "dom",
-      "hydratable": true
-    }]
+    ["../snowpack/plugins/plugin-svelte"]
   ],
   "devOptions": {
     "port": 3002,

--- a/tasks/SnowpackLoader.js
+++ b/tasks/SnowpackLoader.js
@@ -19,7 +19,7 @@ module.exports = class SnowpackLoader {
 		let data;
 
 		try {
-			({ data } = await get(url));
+			({ data } = await get(url+'?ssr=1'));
 		} catch (err) {
 			console.error('>>> error fetching ', url);
 			throw err;


### PR DESCRIPTION
## snowpack-svelte-ssr changes

- Changed the snowpack dependencies from installed packages to local paths.
  - New requirement: the Snowpack repo must be installed as a sibling of this repo
  - rationale: Less error-prone than npm linking, but lmk if you'd prefer any other way to work on both projects together
- HMR now working! 
  - Added `window.HMR_WEBSOCKET_URL =` to the SSR result, so that the client knows where the Snowpack HMR server exists. 
  - If you can set up this server to proxy all websocket requests to the Snowpack server, then this line can be removed.
- Removed second server, took advantage of Snowpack improvements (see below)

## Snowpack changes

*Note: I'm doing work for this  here on a `wip-ssr` branch of https://github.com/pikapkg/snowpack*

- Removed caching for now as a quick fix for the caching issues you were seeing.
- Moved SSR configuration to a boolean that gets passed to each plugin (`load({filePath, isSSR}) {`). No longer a responsibility of the user config.
- Only one dev server now needed to serve both regular and SSR results 

## Commentary

I'd also like to see a better connection with the dev server, using a JS interface instead of HTTP. I believe this would be solved by implementing that middleware, which is the next thing on my list when I next have time to work on this.