### PR TITLE
A second pass at better snowpack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ There are various things not working:
 
 * ~~The aforementioned problem with SSR modules being served to the client~~
 * ~~HMR doesn't seem to work. Haven't investigated why~~
+* ~~The `dev` task runs a Snowpack instance in the background, but all logging gets squelched. Perhaps there's a JavaScript API we could use instead of shelling out to `snowpack`?~~
+* ~~It would be particularly nice if there were a way to load modules from Snowpack that didn't involve fetching them over HTTP and transforming them~~
 * Can this dev server proxy the HMR WebSocket connection to the Snowpack dev server? If so, we can remove the hardcoded `window.HMR_WEBSOCKET_URL =` line.
-* The `dev` task runs a Snowpack instance in the background, but all logging gets squelched. Perhaps there's a JavaScript API we could use instead of shelling out to `snowpack`?
-* It would be particularly nice if there were a way to load modules from Snowpack that didn't involve fetching them over HTTP and transforming them
 * For now there's only a `dev` task. I haven't yet investigated what the `build` task would look like, though I believe the output of `snowpack build` already makes a very useful input to a set of opinionated 'builders' that would take your Sapper app and turn it into packaged assets + cloud functions for places like Vercel, Netlify and so on.
 * In Sapper, CSS is injected into the SSR'd page as `<link>` elements that reflect what's depended on by the current page. Subsequently dynamically imported chunks pull in additional `.css` files as needed. This demo is using a slightly cruder mechanism — I haven't yet explored what it would take to get Sapper's behaviour here.
 * I'd like to flesh this demo out a bit more so that it resembles a more fully-fledged Sapper app (with `preload`, layouts, error pages and so on)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,19 @@
 This is a not-totally-functional experiment to see what it would take to use [Snowpack](https://www.snowpack.dev/) as a base for [Sapper](https://sapper.svelte.dev).
 
 ```bash
+# 1. Check out a local dev branch of the Snowpack repo
+git clone git@github.com:pikapkg/snowpack
+cd snowpack
+git checkout wip-ssr
+yarn install && yarn build && yarn install --force
+cd ../
+
+# 2. Check out this repo (note: must be a sibling directory to "snowpack")
 git clone git@github.com:Rich-Harris/snowpack-svelte
 cd snowpack-svelte
 npm install
 
+# 3. Start the server
 npm start
 ```
 
@@ -25,10 +34,11 @@ As you navigate around, you'll likely see that the browser refreshes the page co
 
 There are various things not working:
 
-* The aforementioned problem with SSR modules being served to the client
-* The `dev` task runs two Snowpack instances in the background, but all their logging gets squelched. Perhaps there's a JavaScript API we could use instead of shelling out to `snowpack`?
+* ~~The aforementioned problem with SSR modules being served to the client~~
+* ~~HMR doesn't seem to work. Haven't investigated why~~
+* Can this dev server proxy the HMR WebSocket connection to the Snowpack dev server? If so, we can remove the hardcoded `window.HMR_WEBSOCKET_URL =` line.
+* The `dev` task runs a Snowpack instance in the background, but all logging gets squelched. Perhaps there's a JavaScript API we could use instead of shelling out to `snowpack`?
 * It would be particularly nice if there were a way to load modules from Snowpack that didn't involve fetching them over HTTP and transforming them
-* HMR doesn't seem to work. Haven't investigated why
 * For now there's only a `dev` task. I haven't yet investigated what the `build` task would look like, though I believe the output of `snowpack build` already makes a very useful input to a set of opinionated 'builders' that would take your Sapper app and turn it into packaged assets + cloud functions for places like Vercel, Netlify and so on.
 * In Sapper, CSS is injected into the SSR'd page as `<link>` elements that reflect what's depended on by the current page. Subsequently dynamically imported chunks pull in additional `.css` files as needed. This demo is using a slightly cruder mechanism — I haven't yet explored what it would take to get Sapper's behaviour here.
 * I'd like to flesh this demo out a bit more so that it resembles a more fully-fledged Sapper app (with `preload`, layouts, error pages and so on)

--- a/sapper/runtime.js
+++ b/sapper/runtime.js
@@ -24,8 +24,6 @@ async function start() {
 
 		// TODO handle preload
 
-		// This often doesn't work, because Snowpack's caching mechanism
-		// gets the SSR and DOM modules mixed up
 		component = new page.default({
 			target: document.body,
 			hydrate: true,

--- a/snowpack/client.config.json
+++ b/snowpack/client.config.json
@@ -3,10 +3,7 @@
     "svelte"
   ],
   "plugins": [
-    ["@snowpack/plugin-svelte", {
-      "generate": "dom",
-      "hydratable": true
-    }]
+    ["../snowpack/plugins/plugin-svelte"]
   ],
   "devOptions": {
     "port": 3002,

--- a/tasks/SnowpackLoader.js
+++ b/tasks/SnowpackLoader.js
@@ -19,7 +19,7 @@ module.exports = class SnowpackLoader {
 		let data;
 
 		try {
-			({ data } = await get(url));
+			({ data } = await get(url+'?ssr=1'));
 		} catch (err) {
 			console.error('>>> error fetching ', url);
 			throw err;

--- a/tasks/SnowpackLoader.js
+++ b/tasks/SnowpackLoader.js
@@ -1,11 +1,11 @@
-const { get } = require('httpie');
 const meriyah = require('meriyah');
 const MagicString = require('magic-string');
 
 // This class makes it possible to load modules from the 'server'
 // snowpack server, for the sake of SSR
 module.exports = class SnowpackLoader {
-	constructor() {
+	constructor({loadByUrl}) {
+		this.loadByUrl = loadByUrl;
 		this.cache = new Map();
 	}
 
@@ -19,7 +19,7 @@ module.exports = class SnowpackLoader {
 		let data;
 
 		try {
-			({ data } = await get(url+'?ssr=1'));
+			( data = await this.loadByUrl(url, {isSSR: true}));
 		} catch (err) {
 			console.error('>>> error fetching ', url);
 			throw err;
@@ -101,8 +101,8 @@ module.exports = class SnowpackLoader {
 
 		const deps = [];
 		imports.forEach(node => {
-			const resolved = new URL(node.source.value, url);
-			const promise = this.load(resolved.href);
+			const resolved = new URL(node.source.value, `http://localhost${url}`);
+			const promise = this.load(resolved.pathname);
 
 			if (node.type === 'ExportAllDeclaration' || node.type === 'ExportNamedDeclaration') {
 				// `export * from './other.js'` or `export { foo } from './other.js'`

--- a/tasks/dev.js
+++ b/tasks/dev.js
@@ -1,17 +1,15 @@
 const http = require('http');
 const fs = require('fs');
-const path = require('path');
-const child_process = require('child_process');
 const http_proxy = require('http-proxy');
 const chokidar = require('chokidar');
 const glob = require('tiny-glob/sync');
 const SnowpackLoader = require('./SnowpackLoader');
 
 // run the Snowpack dev server
+const snowpack = require('../../snowpack/snowpack/pkg');
+const pkgManifest = require('../package.json');
 const config_file_client = 'snowpack/client.config.json';
-const config_client = JSON.parse(fs.readFileSync(config_file_client, 'utf-8'));
-const snowpackBin = path.resolve(__dirname, '../../snowpack/snowpack/pkg/dist-node/index.bin.js');
-const childProcess = child_process.spawn(snowpackBin, ['dev', `--config=${config_file_client}`, '--reload']);
+const config = snowpack.unstable__loadAndValidateConfig({config: config_file_client}, pkgManifest);
 
 // SNOWPACK LOGGING, USEFUL FOR DEBUGGING SNOWPACK ISSUES
 // childProcess.stdout.setEncoding('utf8');
@@ -26,10 +24,6 @@ const childProcess = child_process.spawn(snowpackBin, ['dev', `--config=${config
 // proxy requests for assets (i.e. not page requests, which are SSR'd)
 // to the 'client' snowpack server
 const proxy = http_proxy.createProxyServer();
-
-// create a loader that will request files from the 'server' snowpack
-// server, transform them, and evaluate them
-const loader = new SnowpackLoader();
 
 // create and update a route manifest. this is a super basic version
 // of what Sapper does
@@ -94,28 +88,39 @@ const template = ({ html, head, css }) => `<!DOCTYPE html>
 	</body>
 </html>`;
 
-http.createServer(async (req, res) => {
-	const route = manifest.find(r => r.pattern.test(req.url));
-
-	// if this is an SSR request (URL matches one of the routes),
-	// load the module in question and render the page...
-	if (route && req.headers.upgrade !== 'websocket') {
-		const mod = await loader.load(`http://localhost:${config_client.devOptions.port}/_routes/${route.file.replace('.svelte', '.js')}`);
-
-		const match = route.pattern.exec(req.url);
-		const props = {};
-		route.params.forEach((name, i) => {
-			props[name] = match[i + 1];
-		});
-		const rendered = template(mod.default.render(props));
-		res.setHeader('Content-Type', 'text/html');
-		res.end(rendered);
-
-		return;
-	}
-
-	// ...otherwise defer to Snowpack
-	proxy.web(req, res, {
-		target: `http://localhost:${config_client.devOptions.port}`
+(async () => {
+	const {requestHandler: snowpackMiddleware, loadByUrl} = await snowpack.unstable__startServer({
+		cwd: process.cwd(),
+		config,
+		lockfile: null,
+		pkgManifest,
 	});
-}).listen(3000);
+
+	// create a loader that will request files from the 'server' snowpack
+	// server, transform them, and evaluate them
+	const loader = new SnowpackLoader({loadByUrl});
+
+	http.createServer(async (req, res) => {
+		const route = manifest.find(r => r.pattern.test(req.url));
+
+		// if this is an SSR request (URL matches one of the routes),
+		// load the module in question and render the page...
+		if (route && req.headers.upgrade !== 'websocket') {
+			const mod = await loader.load(`/_routes/${route.file.replace('.svelte', '.js')}`);
+
+			const match = route.pattern.exec(req.url);
+			const props = {};
+			route.params.forEach((name, i) => {
+				props[name] = match[i + 1];
+			});
+			const rendered = template(mod.default.render(props));
+			res.setHeader('Content-Type', 'text/html');
+			res.end(rendered);
+
+			return;
+		}
+
+		// ...otherwise defer to Snowpack middleware
+		return snowpackMiddleware(req, res);
+	}).listen(3000);
+})();


### PR DESCRIPTION
*Note: Since I don't have perms on this repo, this PR has to include the work in #2. [Check out the individual commit](https://github.com/Rich-Harris/snowpack-svelte-ssr/pull/3/commits/06a0aa77dd8084bc519ac42a24f97d8891f66c6f) for a better diff*

## Changes

*Note: I'm doing work for this  here on a `wip-ssr` branch of https://github.com/pikapkg/snowpack*

- Added a JS API for the dev server, so that you don't need to make HTTP requests yourself.
- Added a JS middleware function for use cases like this, and also express apps.
- Updated snowpack-svelte-ssr to take advantage of this

## Commentary

I couldn't help myself :) Snowpack's `loadByUrl` is still making an HTTP request behind the scenes, but now that's just an implementation detail, and something to be improved if we decide to go this route.

I haven't really paid much attention yet to the "source path" vs. "url path" difference in this codebase (all the .replace('svelte', 'js')) but wanted to call out that this is a known problem / something I'm not worried about solving with an exported utility to map between "source path" and "url path". 

@Rich-Harris This is a good place to hand back to you. I'm curious where you could go from here on the Svelte/Sapper side, how the CSS story can be improved, and whether this server can proxy those HMR WebSocket requests so that we can get rid of the `window.HMR_WEBSOCKET_URL` workaround introduced in #2.